### PR TITLE
Clean up configreader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,11 @@ include(FetchContent)
 # -----------------------------------------------------------------------------
 # Fetch simdjson
 # -----------------------------------------------------------------------------
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 FetchContent_Declare(
   simdjson
   GIT_REPOSITORY https://github.com/simdjson/simdjson.git
-  GIT_TAG  v3.1.6
+  GIT_TAG  master
   GIT_SHALLOW TRUE)
 FetchContent_MakeAvailable(simdjson)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(FetchContent)
 FetchContent_Declare(
   simdjson
   GIT_REPOSITORY https://github.com/simdjson/simdjson.git
-  GIT_TAG  master
+  GIT_TAG  v3.1.6
   GIT_SHALLOW TRUE)
 FetchContent_MakeAvailable(simdjson)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,10 @@ include(FetchContent)
 # -----------------------------------------------------------------------------
 # Fetch simdjson
 # -----------------------------------------------------------------------------
-set(CMAKE_POSITION_INDEPENDENT_CODE ON) # Fixes bug with smdjson. Try to remove later
 FetchContent_Declare(
   simdjson
   GIT_REPOSITORY https://github.com/simdjson/simdjson.git
-  GIT_TAG  v2.2.0
+  GIT_TAG  master
   GIT_SHALLOW TRUE)
 FetchContent_MakeAvailable(simdjson)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,6 @@ addopts = """
     --cov-report=html
     --cov-report=term
     --cov=svzerodsolver
+    --ignore=Release
+    --ignore=Debug
 """

--- a/src/helpers/debug.hpp
+++ b/src/helpers/debug.hpp
@@ -36,10 +36,10 @@
 
 #include <iostream>
 
-#ifndef DEBUG
-#define DEBUG_MSG(str)             \
-  do {                             \
-    std::cout << str << std::endl; \
+#ifndef NDEBUG
+#define DEBUG_MSG(str)                                   \
+  do {                                                   \
+    std::cout << "[DEBUG MESSAGE] " << str << std::endl; \
   } while (false)
 #else
 #define DEBUG_MSG(str) \

--- a/src/interface/interface.cpp
+++ b/src/interface/interface.cpp
@@ -35,6 +35,8 @@
 
 #include <cmath>
 
+#include "io/jsonhandler.hpp"
+
 typedef double T;
 
 template <typename TT>
@@ -120,7 +122,12 @@ void initialize(std::string input_file_arg, int& problem_id, int& pts_per_cycle,
 
   // Create configuration reader.
   IO::ConfigReader<T> reader;
-  reader.load(input_file);
+  std::ifstream input_file_stream(input_file);
+  std::stringstream buffer;
+  buffer << input_file_stream.rdbuf();
+  std::string json_config = buffer.str();
+  auto handler = IO::JsonHandler(json_config);
+  reader.load(handler);
 
   // Create a model.
   auto model = reader.model;

--- a/src/io/configreader.hpp
+++ b/src/io/configreader.hpp
@@ -56,7 +56,6 @@
 #include "../model/resistivejunction.hpp"
 #include "../model/windkesselbc.hpp"
 #include "./jsonhandler.hpp"
-#include "simdjson.h"
 
 namespace IO {
 
@@ -79,9 +78,9 @@ class ConfigReader {
   ~ConfigReader();
 
   /**
-   * @brief Create model from configuration file
+   * @brief Create model from configuration
    *
-   * @return Model
+   * @param handler Configuration handler
    */
   void load(JsonHandler &handler);
 

--- a/src/io/configreader.hpp
+++ b/src/io/configreader.hpp
@@ -623,8 +623,8 @@ void ConfigReader<T>::load(JsonHandler &handler) {
           for (auto outlet_block :
                closed_loop_config.get_string_array("outlet_blocks")) {
             connections.push_back({heart_outlet_junction_name, outlet_block});
-            block_count++;
           }
+          block_count++;
         } else {
           throw std::runtime_error(
               "Error. Only one ClosedLoopHeartAndPulmonary can be included.");

--- a/src/io/configreader.hpp
+++ b/src/io/configreader.hpp
@@ -55,6 +55,7 @@
 #include "../model/resistancebc.hpp"
 #include "../model/resistivejunction.hpp"
 #include "../model/windkesselbc.hpp"
+#include "./jsonhandler.hpp"
 #include "simdjson.h"
 
 namespace IO {
@@ -82,7 +83,7 @@ class ConfigReader {
    *
    * @return Model
    */
-  void load(std::string &specifier);
+  void load(JsonHandler &handler);
 
   MODEL::Model<T> *model;           ///< Simulation model
   ALGEBRA::State<T> initial_state;  ///< Initial state
@@ -117,120 +118,57 @@ template <typename T>
 ConfigReader<T>::~ConfigReader() {}
 
 template <typename T>
-void ConfigReader<T>::load(std::string &specifier) {
-  DEBUG_MSG("Start ConfigReader::load");
+void ConfigReader<T>::load(JsonHandler &handler) {
+  DEBUG_MSG("Start loading configuration");
   // Initialize model pointer
   model = new MODEL::Model<T>();
 
-  // Create iterator for json configuration
-  simdjson::ondemand::parser parser;
-  simdjson::padded_string string;
-  if (HELPERS::startswith(specifier, "{")) {
-    string = simdjson::padded_string(specifier);
-  } else {
-    string = simdjson::padded_string::load(specifier);
-  }
-  DEBUG_MSG("Loaded svZeroD config file. Starting parsing.");
-  auto config = parser.iterate(string);
-
   // Load simulation parameters
-  auto sim_params = config["simulation_parameters"];
-  try {
-    sim_coupled = sim_params["coupled_simulation"].get_bool();
-  } catch (simdjson::simdjson_error) {
-    sim_coupled = false;
-  }
+  DEBUG_MSG("Load simulation parameters");
+  auto sim_params = handler["simulation_parameters"];
+  sim_coupled = sim_params.get_bool("coupled_simulation", false);
   if (!sim_coupled) {
-    sim_num_cycles = sim_params["number_of_cardiac_cycles"].get_int64();
+    sim_num_cycles = sim_params.get_int("number_of_cardiac_cycles");
     sim_pts_per_cycle =
-        sim_params["number_of_time_pts_per_cardiac_cycle"].get_int64();
-    sim_num_time_steps = (sim_pts_per_cycle - 1.0) * sim_num_cycles + 1.0;
+        sim_params.get_int("number_of_time_pts_per_cardiac_cycle");
+    sim_num_time_steps = (sim_pts_per_cycle - 1) * sim_num_cycles + 1;
     sim_external_step_size = 0.0;
   } else {
     sim_num_cycles = 1;
-    sim_num_time_steps = sim_params["number_of_time_pts"].get_int64();
+    sim_num_time_steps = sim_params.get_int("number_of_time_pts");
     sim_pts_per_cycle = sim_num_time_steps;
-    try {
-      sim_external_step_size = sim_params["external_step_size"].get_double();
-    } catch (simdjson::simdjson_error) {
-      sim_external_step_size = 0.1;
-    }
+    sim_external_step_size = sim_params.get_double("external_step_size", 0.1);
   }
   sim_cardiac_cycle_period = -1.0;  // Negative value indicates this has not
                                     // been read from config file yet.
-  try {
-    sim_abs_tol = sim_params["absolute_tolerance"].get_double();
-  } catch (simdjson::simdjson_error) {
-    sim_abs_tol = 1e-8;
-  }
-  try {
-    sim_nliter = sim_params["maximum_nonlinear_iterations"].get_int64();
-  } catch (simdjson::simdjson_error) {
-    sim_nliter = 30;
-  }
-  try {
-    sim_steady_initial = sim_params["steady_initial"].get_bool();
-  } catch (simdjson::simdjson_error) {
-    sim_steady_initial = true;
-  }
-  try {
-    output_variable_based = sim_params["output_variable_based"].get_bool();
-  } catch (simdjson::simdjson_error) {
-    output_variable_based = false;
-  }
-  try {
-    output_interval = sim_params["output_interval"].get_int64();
-  } catch (simdjson::simdjson_error) {
-    output_interval = 1;
-  }
-  try {
-    output_mean_only = sim_params["output_mean_only"].get_bool();
-  } catch (simdjson::simdjson_error) {
-    output_mean_only = false;
-  }
-  try {
-    output_derivative = sim_params["output_derivative"].get_bool();
-  } catch (simdjson::simdjson_error) {
-    output_derivative = false;
-  }
-  try {
-    output_last_cycle_only = sim_params["output_last_cycle_only"].get_bool();
-  } catch (simdjson::simdjson_error) {
-    output_last_cycle_only = false;
-  }
+  sim_abs_tol = sim_params.get_double("absolute_tolerance", 1e-8);
+  sim_nliter = sim_params.get_int("maximum_nonlinear_iterations", 30);
+  sim_steady_initial = sim_params.get_bool("steady_initial", true);
+  output_variable_based = sim_params.get_bool("output_variable_based", false);
+  output_interval = sim_params.get_int("output_interval", 1);
+  output_mean_only = sim_params.get_bool("output_mean_only", false);
+  output_derivative = sim_params.get_bool("output_derivative", false);
+  output_last_cycle_only = sim_params.get_bool("output_last_cycle_only", false);
 
   // Create list to store block connections while generating blocks
   std::vector<std::tuple<std::string_view, std::string_view>> connections;
   int block_count = 0;
 
   // Create vessels
+  DEBUG_MSG("Load vessels");
   std::map<std::int64_t, std::string_view> vessel_id_map;
-  for (auto vessel_config : config["vessels"]) {
+  auto vessels = handler["vessels"];
+  for (size_t i = 0; i < vessels.length(); i++) {
+    auto vessel_config = vessels[i];
     auto vessel_values = vessel_config["zero_d_element_values"];
-    std::string_view vessel_name = vessel_config["vessel_name"].get_string();
-    vessel_id_map.insert({vessel_config["vessel_id"].get_int64(), vessel_name});
-    if (std::string_view(vessel_config["zero_d_element_type"].get_string()) ==
-        "BloodVessel") {
-      T R = vessel_values["R_poiseuille"].get_double();
-      T C;
-      try {
-        C = vessel_values["C"].get_double();
-      } catch (simdjson::simdjson_error) {
-        C = 0.0;
-      }
-      T L;
-      try {
-        L = vessel_values["L"].get_double();
-      } catch (simdjson::simdjson_error) {
-        L = 0.0;
-      }
-      T stenosis_coefficient;
-      try {
-        stenosis_coefficient =
-            vessel_values["stenosis_coefficient"].get_double();
-      } catch (simdjson::simdjson_error) {
-        stenosis_coefficient = 0.0;
-      }
+    std::string_view vessel_name = vessel_config.get_string("vessel_name");
+    vessel_id_map.insert({vessel_config.get_int("vessel_id"), vessel_name});
+    if (vessel_config.get_string("zero_d_element_type") == "BloodVessel") {
+      T R = vessel_values.get_double("R_poiseuille");
+      T C = vessel_values.get_double("C", 0.0);
+      T L = vessel_values.get_double("L", 0.0);
+      T stenosis_coefficient =
+          vessel_values.get_double("stenosis_coefficient", 0.0);
       model->blocks.push_back(new MODEL::BloodVessel<T>(
           R = R, C = C, L = L, stenosis_coefficient = stenosis_coefficient,
           static_cast<std::string>(vessel_name)));
@@ -243,58 +181,45 @@ void ConfigReader<T>::load(std::string &specifier) {
     }
 
     // Read connected boundary conditions
-    try {
-      auto inlet_bc = vessel_config["boundary_conditions"]["inlet"];
-      connections.push_back({inlet_bc.get_string(), vessel_name});
-    } catch (simdjson::simdjson_error) {
-    }
-
-    try {
-      auto outlet_bc = vessel_config["boundary_conditions"]["outlet"];
-      connections.push_back({vessel_name, outlet_bc.get_string()});
-    } catch (simdjson::simdjson_error) {
+    if (vessel_config.has_key("boundary_conditions")) {
+      auto vessel_bc_config = vessel_config["boundary_conditions"];
+      if (vessel_bc_config.has_key("inlet")) {
+        connections.push_back(
+            {vessel_bc_config.get_string("inlet"), vessel_name});
+      }
+      if (vessel_bc_config.has_key("outlet")) {
+        connections.push_back(
+            {vessel_name, vessel_bc_config.get_string("outlet")});
+      }
     }
   }
 
   // Create map for boundary conditions to boundary condition type
+  DEBUG_MSG("Create BC name to BC type map");
+  auto bc_configs = handler["boundary_conditions"];
   std::map<std::string_view, std::string_view> bc_type_map;
-  for (auto bc_config : config["boundary_conditions"]) {
-    bc_type_map.insert({bc_config["bc_name"], bc_config["bc_type"]});
+  for (size_t i = 0; i < bc_configs.length(); i++) {
+    auto bc_config = bc_configs[i];
+    bc_type_map.insert(
+        {bc_config.get_string("bc_name"), bc_config.get_string("bc_type")});
   }
-  DEBUG_MSG("Created BC name->type map.");
 
-  try {
-    for (auto coupling_config : config["external_solver_coupling_blocks"]) {
-      std::string_view coupling_type = coupling_config["type"];
-      std::string_view coupling_name = coupling_config["name"];
-      std::string_view coupling_loc = coupling_config["location"];
-      bool periodic;
-      try {
-        periodic = coupling_config["periodic"].get_bool();
-      } catch (simdjson::simdjson_error) {
-        periodic = true;
-      }
+  if (handler.has_key("external_solver_coupling_blocks")) {
+    DEBUG_MSG("Create external coupling blocks");
+    auto coupling_configs = handler["external_solver_coupling_blocks"];
+    for (size_t i = 0; i < coupling_configs.length(); i++) {
+      auto coupling_config = coupling_configs[i];
+      auto coupling_type = coupling_config.get_string("type");
+      auto coupling_name = coupling_config.get_string("name");
+      auto coupling_loc = coupling_config.get_string("location");
+      bool periodic = coupling_config.get_bool("periodic", true);
       auto coupling_values = coupling_config["values"];
 
       // Create coupling block
-      std::vector<T> t_coupling;
-      try {
-        for (auto x : coupling_values["t"]) {
-          t_coupling.push_back(x.get_double());
-        }
-      } catch (simdjson::simdjson_error) {
-        t_coupling.push_back(0.0);
-      };
+      auto t_coupling = coupling_values.get_double_array("t", {0.0});
 
       if (coupling_type == "FLOW") {
-        std::vector<T> Q_coupling;
-        try {
-          for (auto x : coupling_values["Q"].get_array()) {
-            Q_coupling.push_back(x.get_double());
-          }
-        } catch (simdjson::simdjson_error) {
-          Q_coupling.push_back(coupling_values["Q"].get_double());
-        }
+        auto Q_coupling = coupling_values.get_double_array("Q");
 
         MODEL::TimeDependentParameter q_coupling_param(t_coupling, Q_coupling,
                                                        periodic);
@@ -318,14 +243,7 @@ void ConfigReader<T>::load(std::string &specifier) {
         model->external_coupling_blocks.push_back(
             static_cast<std::string>(coupling_name));
       } else if (coupling_type == "PRESSURE") {
-        std::vector<T> P_coupling;
-        try {
-          for (auto x : coupling_values["P"].get_array()) {
-            P_coupling.push_back(x.get_double());
-          }
-        } catch (simdjson::simdjson_error) {
-          P_coupling.push_back(coupling_values["P"].get_double());
-        }
+        auto P_coupling = coupling_values.get_double_array("P");
         MODEL::TimeDependentParameter p_coupling_param(t_coupling, P_coupling,
                                                        periodic);
         if ((p_coupling_param.isconstant == false) &&
@@ -355,7 +273,7 @@ void ConfigReader<T>::load(std::string &specifier) {
       DEBUG_MSG("Created coupling block " << coupling_name);
 
       // Determine the type of connected block
-      std::string_view connected_block = coupling_config["connected_block"];
+      auto connected_block = coupling_config.get_string("connected_block");
       std::string_view connected_type;
       int found_block = 0;
       if (connected_block == "ClosedLoopHeartAndPulmonary") {
@@ -417,40 +335,36 @@ void ConfigReader<T>::load(std::string &specifier) {
                     << connected_block << "-> " << coupling_name);
         }  // connected_type == "ClosedLoopRCR"
       }    // coupling_loc
-    }  // for (auto coupling_config : config["external_solver_coupling_blocks"])
-  } catch (simdjson::simdjson_error) {
+    }      // for (size_t i = 0; i < coupling_configs.length(); i++)
   }
-  DEBUG_MSG("Finished creating external coupling blocks.");
 
   std::vector<std::string_view> closed_loop_bcs;
 
   // Create boundary conditions
-  for (auto bc_config : config["boundary_conditions"]) {
-    std::string_view bc_type = bc_config["bc_type"];
-    std::string_view bc_name = bc_config["bc_name"];
+  DEBUG_MSG("Create boundary conditions");
+  for (size_t i = 0; i < bc_configs.length(); i++) {
+    auto bc_config = bc_configs[i];
+    auto bc_type = bc_config.get_string("bc_type");
+    auto bc_name = bc_config.get_string("bc_name");
     auto bc_values = bc_config["bc_values"];
 
-    std::vector<T> t;
-    try {
-      for (auto x : bc_values["t"]) {
-        t.push_back(x.get_double());
-      }
-    } catch (simdjson::simdjson_error) {
-      t.push_back(0.0);
-    };
+    auto t = bc_values.get_double_array("t", {0.0});
 
     if (bc_type == "RCR") {
-      T Rp = bc_values["Rp"], C = bc_values["C"], Rd = bc_values["Rd"],
-        Pd = bc_values["Pd"];
+      T Rp = bc_values.get_double("Rp");
+      T C = bc_values.get_double("C");
+      T Rd = bc_values.get_double("Rd");
+      T Pd = bc_values.get_double("Pd");
       model->blocks.push_back(new MODEL::WindkesselBC<T>(
           Rp = Rp, C = C, Rd = Rd, Pd = Pd, static_cast<std::string>(bc_name)));
       model->block_index_map.insert(
           {static_cast<std::string>(bc_name), block_count});
-      block_count++;
-      DEBUG_MSG("Created boundary condition " << bc_name);
+
     } else if (bc_type == "ClosedLoopRCR") {
-      T Rp = bc_values["Rp"], C = bc_values["C"], Rd = bc_values["Rd"];
-      bool closed_loop_outlet = bc_values["closed_loop_outlet"];
+      T Rp = bc_values.get_double("Rp");
+      T C = bc_values.get_double("C");
+      T Rd = bc_values.get_double("Rd");
+      bool closed_loop_outlet = bc_values.get_bool("closed_loop_outlet");
       if (closed_loop_outlet == true) {
         closed_loop_bcs.push_back(bc_name);
       }
@@ -459,17 +373,8 @@ void ConfigReader<T>::load(std::string &specifier) {
           static_cast<std::string>(bc_name)));
       model->block_index_map.insert(
           {static_cast<std::string>(bc_name), block_count});
-      block_count++;
-      DEBUG_MSG("Created boundary condition " << bc_name);
     } else if (bc_type == "FLOW") {
-      std::vector<T> Q;
-      try {
-        for (auto x : bc_values["Q"].get_array()) {
-          Q.push_back(x.get_double());
-        }
-      } catch (simdjson::simdjson_error) {
-        Q.push_back(bc_values["Q"].get_double());
-      }
+      auto Q = bc_values.get_double_array("Q");
 
       MODEL::TimeDependentParameter q_param(t, Q);
       if ((q_param.isconstant == false) && (q_param.isperiodic == true)) {
@@ -486,47 +391,21 @@ void ConfigReader<T>::load(std::string &specifier) {
           q_param, static_cast<std::string>(bc_name)));
       model->block_index_map.insert(
           {static_cast<std::string>(bc_name), block_count});
-      block_count++;
-      DEBUG_MSG("Created boundary condition " << bc_name);
 
     } else if (bc_type == "RESISTANCE") {
-      std::vector<T> R;
-      try {
-        for (auto x : bc_values["R"].get_array()) {
-          R.push_back(x.get_double());
-        }
-      } catch (simdjson::simdjson_error) {
-        R.push_back(bc_values["R"].get_double());
-      }
+      auto R = bc_values.get_double_array("R");
       MODEL::TimeDependentParameter r_param(t, R);
 
-      std::vector<T> Pd;
-      try {
-        for (auto x : bc_values["Pd"].get_array()) {
-          Pd.push_back(x.get_double());
-        }
-      } catch (simdjson::simdjson_error) {
-        Pd.push_back(bc_values["Pd"].get_double());
-      }
+      auto Pd = bc_values.get_double_array("Pd");
       MODEL::TimeDependentParameter pd_param(t, Pd);
       model->blocks.push_back(new MODEL::ResistanceBC<T>(
           r_param, pd_param, static_cast<std::string>(bc_name)));
       model->block_index_map.insert(
           {static_cast<std::string>(bc_name), block_count});
-      block_count++;
-      DEBUG_MSG("Created boundary condition " << bc_name);
     } else if (bc_type == "PRESSURE") {
-      std::vector<T> P;
-      try {
-        for (auto x : bc_values["P"].get_array()) {
-          P.push_back(x.get_double());
-        }
-      } catch (simdjson::simdjson_error) {
-        P.push_back(bc_values["P"].get_double());
-      }
+      auto P = bc_values.get_double_array("P");
       MODEL::TimeDependentParameter p_param(t, P);
       if ((p_param.isconstant == false) && (p_param.isperiodic == true)) {
-        // if (p_param.isconstant == false) {
         if ((sim_cardiac_cycle_period > 0.0) &&
             (p_param.cycle_period != sim_cardiac_cycle_period)) {
           throw std::runtime_error(
@@ -540,30 +419,16 @@ void ConfigReader<T>::load(std::string &specifier) {
           p_param, static_cast<std::string>(bc_name)));
       model->block_index_map.insert(
           {static_cast<std::string>(bc_name), block_count});
-      block_count++;
-      DEBUG_MSG("Created boundary condition " << bc_name);
     } else if (bc_type == "CORONARY") {
-      T Ra = bc_values["Ra1"], Ram = bc_values["Ra2"], Rv = bc_values["Rv1"],
-        Ca = bc_values["Ca"], Cim = bc_values["Cc"];
-      auto Pim_json = bc_values["Pim"], Pv_json = bc_values["P_v"];
+      T Ra = bc_values.get_double("Ra1");
+      T Ram = bc_values.get_double("Ra2");
+      T Rv = bc_values.get_double("Rv1");
+      T Ca = bc_values.get_double("Ca");
+      T Cim = bc_values.get_double("Cc");
 
-      std::vector<T> Pim;
-      try {
-        for (auto x : bc_values["Pim"].get_array()) {
-          Pim.push_back(x.get_double());
-        }
-      } catch (simdjson::simdjson_error) {
-        Pim.push_back(bc_values["Pim"].get_double());
-      }
+      auto Pim = bc_values.get_double_array("Pim");
       MODEL::TimeDependentParameter pim_param(t, Pim);
-      std::vector<T> P_v;
-      try {
-        for (auto x : bc_values["P_v"].get_array()) {
-          P_v.push_back(x.get_double());
-        }
-      } catch (simdjson::simdjson_error) {
-        P_v.push_back(bc_values["P_v"].get_double());
-      }
+      auto P_v = bc_values.get_double_array("P_v");
       MODEL::TimeDependentParameter pv_param(t, P_v);
 
       model->blocks.push_back(new MODEL::OpenLoopCoronaryBC<T>(
@@ -571,84 +436,68 @@ void ConfigReader<T>::load(std::string &specifier) {
           static_cast<std::string>(bc_name)));
       model->block_index_map.insert(
           {static_cast<std::string>(bc_name), block_count});
-      block_count++;
-      DEBUG_MSG("Created boundary condition " << bc_name);
     } else if (bc_type == "ClosedLoopCoronary") {
-      T Ra = bc_values["Ra"], Ram = bc_values["Ram"], Rv = bc_values["Rv"],
-        Ca = bc_values["Ca"], Cim = bc_values["Cim"];
-      std::string_view side = bc_values["side"];
+      auto Ra = bc_values.get_double("Ra");
+      auto Ram = bc_values.get_double("Ram");
+      auto Rv = bc_values.get_double("Rv");
+      auto Ca = bc_values.get_double("Ca");
+      auto Cim = bc_values.get_double("Cim");
+      auto side = bc_values.get_string("side");
       closed_loop_bcs.push_back(bc_name);
       model->blocks.push_back(new MODEL::ClosedLoopCoronaryBC<T>(
           Ra = Ra, Ram = Ram, Rv = Rv, Ca = Ca, Cim = Cim,
           static_cast<std::string>(side), static_cast<std::string>(bc_name)));
       model->block_index_map.insert(
           {static_cast<std::string>(bc_name), block_count});
-      block_count++;
-      DEBUG_MSG("Created boundary condition " << bc_name);
     } else {
       throw std::invalid_argument("Unknown boundary condition type");
     }
+    block_count++;
+    DEBUG_MSG("Created boundary condition " << bc_name);
   }
 
   // Create junctions
-  for (auto junction_config : config["junctions"]) {
-    std::string_view j_type = junction_config["junction_type"].get_string();
-    std::string_view junction_name =
-        junction_config["junction_name"].get_string();
+  auto junctions = handler["junctions"];
+  for (size_t i = 0; i < junctions.length(); i++) {
+    auto junction_config = junctions[i];
+    auto j_type = junction_config.get_string("junction_type");
+    auto junction_name = junction_config.get_string("junction_name");
     if ((j_type == "NORMAL_JUNCTION") || (j_type == "internal_junction")) {
       model->blocks.push_back(
           new MODEL::Junction<T>(static_cast<std::string>(junction_name)));
       model->block_index_map.insert(
           {static_cast<std::string>(junction_name), block_count});
-      block_count++;
     } else if (j_type == "resistive_junction") {
-      std::vector<T> R;
-      for (auto x : junction_config["junction_values"]["R"].get_array()) {
-        R.push_back(x.get_double());
-      }
+      auto junction_values = junction_config["junction_values"];
+      auto R = junction_values.get_double_array("R");
       model->blocks.push_back(new MODEL::ResistiveJunction<T>(
           R, static_cast<std::string>(junction_name)));
       model->block_index_map.insert(
           {static_cast<std::string>(junction_name), block_count});
-      block_count++;
     } else if (j_type == "BloodVesselJunction") {
-      std::vector<T> R;
-      std::vector<T> C;
-      std::vector<T> L;
-      std::vector<T> stenosis_coefficient;
-      for (auto x :
-           junction_config["junction_values"]["R_poiseuille"].get_array()) {
-        R.push_back(x.get_double());
-      }
-      for (auto x : junction_config["junction_values"]["C"].get_array()) {
-        C.push_back(x.get_double());
-      }
-      for (auto x : junction_config["junction_values"]["L"].get_array()) {
-        L.push_back(x.get_double());
-      }
-      for (auto x : junction_config["junction_values"]["stenosis_coefficient"]
-                        .get_array()) {
-        stenosis_coefficient.push_back(x.get_double());
-      }
+      auto junction_values = junction_config["junction_values"];
+      auto R = junction_values.get_double_array("R_poiseuille");
+      auto C = junction_values.get_double_array("C");
+      auto L = junction_values.get_double_array("L");
+      auto stenosis_coefficient =
+          junction_values.get_double_array("stenosis_coefficient");
       model->blocks.push_back(new MODEL::BloodVesselJunction<T>(
           R, C, L, stenosis_coefficient,
           static_cast<std::string>(junction_name)));
       model->block_index_map.insert(
           {static_cast<std::string>(junction_name), block_count});
-      block_count++;
     } else {
       throw std::invalid_argument("Unknown junction type");
     }
     // Check for connections to inlet and outlet vessels and append to
     // connections list
-    for (auto inlet_vessel : junction_config["inlet_vessels"]) {
-      connections.push_back(
-          {vessel_id_map[inlet_vessel.get_int64()], junction_name});
+    for (auto vessel_id : junction_config.get_int_array("inlet_vessels")) {
+      connections.push_back({vessel_id_map[vessel_id], junction_name});
     }
-    for (auto outlet_vessel : junction_config["outlet_vessels"]) {
-      connections.push_back(
-          {junction_name, vessel_id_map[outlet_vessel.get_int64()]});
+    for (auto vessel_id : junction_config.get_int_array("outlet_vessels")) {
+      connections.push_back({junction_name, vessel_id_map[vessel_id]});
     }
+    block_count++;
     DEBUG_MSG("Created junction " << junction_name);
   }
 
@@ -656,10 +505,11 @@ void ConfigReader<T>::load(std::string &specifier) {
   bool heartpulmonary_block_present =
       false;  ///< Flag to check if heart block is present (requires different
               ///< handling)
-  try {
-    for (auto closed_loop_config : config["closed_loop_blocks"]) {
-      std::string_view closed_loop_type =
-          closed_loop_config["closed_loop_type"];
+  if (handler.has_key("closed_loop_blocks")) {
+    auto closed_loop_configs = handler["closed_loop_blocks"];
+    for (size_t i = 0; i < closed_loop_configs.length(); i++) {
+      auto closed_loop_config = closed_loop_configs[i];
+      auto closed_loop_type = closed_loop_config.get_string("closed_loop_type");
       if (closed_loop_type == "ClosedLoopHeartAndPulmonary") {
         if (heartpulmonary_block_present == false) {
           heartpulmonary_block_present = true;
@@ -671,7 +521,7 @@ void ConfigReader<T>::load(std::string &specifier) {
           sim_steady_initial = false;
           std::string_view heartpulmonary_name = "CLH";
           T cycle_period =
-              closed_loop_config["cardiac_cycle_period"].get_double();
+              closed_loop_config.get_double("cardiac_cycle_period");
           if ((sim_cardiac_cycle_period > 0.0) &&
               (cycle_period != sim_cardiac_cycle_period)) {
             throw std::runtime_error(
@@ -683,44 +533,66 @@ void ConfigReader<T>::load(std::string &specifier) {
           auto heart_params = closed_loop_config["parameters"];
           // Convert to std::map to keep model blocks independent of simdjson
           std::map<std::string, T> param_values;
-          param_values.insert(std::make_pair("Tsa", heart_params["Tsa"]));
-          param_values.insert(std::make_pair("tpwave", heart_params["tpwave"]));
-          param_values.insert(std::make_pair("Erv_s", heart_params["Erv_s"]));
-          param_values.insert(std::make_pair("Elv_s", heart_params["Elv_s"]));
-          param_values.insert(std::make_pair("iml", heart_params["iml"]));
-          param_values.insert(std::make_pair("imr", heart_params["imr"]));
-          param_values.insert(std::make_pair("Lra_v", heart_params["Lra_v"]));
-          param_values.insert(std::make_pair("Rra_v", heart_params["Rra_v"]));
-          param_values.insert(std::make_pair("Lrv_a", heart_params["Lrv_a"]));
-          param_values.insert(std::make_pair("Rrv_a", heart_params["Rrv_a"]));
-          param_values.insert(std::make_pair("Lla_v", heart_params["Lla_v"]));
-          param_values.insert(std::make_pair("Rla_v", heart_params["Rla_v"]));
-          param_values.insert(std::make_pair("Llv_a", heart_params["Llv_a"]));
-          param_values.insert(std::make_pair("Rlv_ao", heart_params["Rlv_ao"]));
-          param_values.insert(std::make_pair("Vrv_u", heart_params["Vrv_u"]));
-          param_values.insert(std::make_pair("Vlv_u", heart_params["Vlv_u"]));
-          param_values.insert(std::make_pair("Rpd", heart_params["Rpd"]));
-          param_values.insert(std::make_pair("Cp", heart_params["Cp"]));
-          param_values.insert(std::make_pair("Cpa", heart_params["Cpa"]));
-          param_values.insert(std::make_pair("Kxp_ra", heart_params["Kxp_ra"]));
-          param_values.insert(std::make_pair("Kxv_ra", heart_params["Kxv_ra"]));
-          param_values.insert(std::make_pair("Kxp_la", heart_params["Kxp_la"]));
-          param_values.insert(std::make_pair("Kxv_la", heart_params["Kxv_la"]));
           param_values.insert(
-              std::make_pair("Emax_ra", heart_params["Emax_ra"]));
+              std::make_pair("Tsa", heart_params.get_double("Tsa")));
           param_values.insert(
-              std::make_pair("Emax_la", heart_params["Emax_la"]));
+              std::make_pair("tpwave", heart_params.get_double("tpwave")));
           param_values.insert(
-              std::make_pair("Vaso_ra", heart_params["Vaso_ra"]));
+              std::make_pair("Erv_s", heart_params.get_double("Erv_s")));
           param_values.insert(
-              std::make_pair("Vaso_la", heart_params["Vaso_la"]));
+              std::make_pair("Elv_s", heart_params.get_double("Elv_s")));
+          param_values.insert(
+              std::make_pair("iml", heart_params.get_double("iml")));
+          param_values.insert(
+              std::make_pair("imr", heart_params.get_double("imr")));
+          param_values.insert(
+              std::make_pair("Lra_v", heart_params.get_double("Lra_v")));
+          param_values.insert(
+              std::make_pair("Rra_v", heart_params.get_double("Rra_v")));
+          param_values.insert(
+              std::make_pair("Lrv_a", heart_params.get_double("Lrv_a")));
+          param_values.insert(
+              std::make_pair("Rrv_a", heart_params.get_double("Rrv_a")));
+          param_values.insert(
+              std::make_pair("Lla_v", heart_params.get_double("Lla_v")));
+          param_values.insert(
+              std::make_pair("Rla_v", heart_params.get_double("Rla_v")));
+          param_values.insert(
+              std::make_pair("Llv_a", heart_params.get_double("Llv_a")));
+          param_values.insert(
+              std::make_pair("Rlv_ao", heart_params.get_double("Rlv_ao")));
+          param_values.insert(
+              std::make_pair("Vrv_u", heart_params.get_double("Vrv_u")));
+          param_values.insert(
+              std::make_pair("Vlv_u", heart_params.get_double("Vlv_u")));
+          param_values.insert(
+              std::make_pair("Rpd", heart_params.get_double("Rpd")));
+          param_values.insert(
+              std::make_pair("Cp", heart_params.get_double("Cp")));
+          param_values.insert(
+              std::make_pair("Cpa", heart_params.get_double("Cpa")));
+          param_values.insert(
+              std::make_pair("Kxp_ra", heart_params.get_double("Kxp_ra")));
+          param_values.insert(
+              std::make_pair("Kxv_ra", heart_params.get_double("Kxv_ra")));
+          param_values.insert(
+              std::make_pair("Kxp_la", heart_params.get_double("Kxp_la")));
+          param_values.insert(
+              std::make_pair("Kxv_la", heart_params.get_double("Kxv_la")));
+          param_values.insert(
+              std::make_pair("Emax_ra", heart_params.get_double("Emax_ra")));
+          param_values.insert(
+              std::make_pair("Emax_la", heart_params.get_double("Emax_la")));
+          param_values.insert(
+              std::make_pair("Vaso_ra", heart_params.get_double("Vaso_ra")));
+          param_values.insert(
+              std::make_pair("Vaso_la", heart_params.get_double("Vaso_la")));
           if (param_values.size() == 27) {
             model->blocks.push_back(new MODEL::ClosedLoopHeartPulmonary<T>(
                 param_values, cycle_period,
                 static_cast<std::string>(heartpulmonary_name)));
             model->block_index_map.insert(
                 {static_cast<std::string>(heartpulmonary_name), block_count});
-            block_count++;
           } else {
             throw std::runtime_error(
                 "Error. ClosedLoopHeartAndPulmonary should have 27 parameters");
@@ -734,7 +606,6 @@ void ConfigReader<T>::load(std::string &specifier) {
           model->block_index_map.insert(
               {static_cast<std::string>(heart_inlet_junction_name),
                block_count});
-          block_count++;
           for (auto heart_inlet_elem : closed_loop_bcs) {
             connections.push_back(
                 {heart_inlet_elem, heart_inlet_junction_name});
@@ -748,18 +619,17 @@ void ConfigReader<T>::load(std::string &specifier) {
           model->block_index_map.insert(
               {static_cast<std::string>(heart_outlet_junction_name),
                block_count});
-          block_count++;
-          for (auto heart_outlet_block : closed_loop_config["outlet_blocks"]) {
-            connections.push_back(
-                {heart_outlet_junction_name, heart_outlet_block});
+          for (auto outlet_block :
+               closed_loop_config.get_string_array("outlet_blocks")) {
+            connections.push_back({heart_outlet_junction_name, outlet_block});
           }
         } else {
           throw std::runtime_error(
               "Error. Only one ClosedLoopHeartAndPulmonary can be included.");
         }
+        block_count++;
       }
     }
-  } catch (simdjson::simdjson_error) {
   }
 
   // Create Connections
@@ -810,46 +680,36 @@ void ConfigReader<T>::load(std::string &specifier) {
   for (auto &block : model->blocks) {
     block->set_ICs(initial_state);
   }
-  try {
-    auto initial_condition = config["initial_condition"].value();
+  if (handler.has_key("initial_condition")) {
+    auto initial_condition = handler["initial_condition"];
     // Check for pressure_all or flow_all condition.
     // This will initialize all pressure:* and flow:* variables.
     T init_p, init_q;
-    bool init_p_flag = false;
-    bool init_q_flag = false;
-    try {
-      init_p = initial_condition["pressure_all"];
-      init_p_flag = true;
-    } catch (simdjson::simdjson_error) {
+    bool init_p_flag = initial_condition.has_key("pressure_all");
+    bool init_q_flag = initial_condition.has_key("flow_all");
+    if (init_p_flag) {
+      init_p = initial_condition.get_double("pressure_all");
     }
-    try {
-      init_q = initial_condition["flow_all"];
-      init_q_flag = true;
-    } catch (simdjson::simdjson_error) {
+    if (init_q_flag) {
+      init_q = initial_condition.get_double("flow_all");
     }
+
     // Loop through variables and check for initial conditions.
     for (size_t i = 0; i < model->dofhandler.size(); i++) {
-      try {
-        initial_state.y[i] = initial_condition[model->dofhandler.variables[i]];
-      } catch (simdjson::simdjson_error) {
-        std::string var_name = model->dofhandler.variables[i];
-        if ((init_p_flag == true) && ((var_name.substr(0, 9) == "pressure:") ||
-                                      (var_name.substr(0, 4) == "P_c:"))) {
-          initial_state.y[i] = init_p;
-          DEBUG_MSG("pressure_all initial condition for "
-                    << model->dofhandler.variables[i]);
-        } else if ((init_q_flag == true) &&
-                   (var_name.substr(0, 5) == "flow:")) {
-          initial_state.y[i] = init_q;
-          DEBUG_MSG("flow_all initial condition for "
-                    << model->dofhandler.variables[i]);
-        } else {
-          DEBUG_MSG("No initial condition found for "
-                    << model->dofhandler.variables[i]);
-        }
+      std::string var_name = model->dofhandler.variables[i];
+      double default_val = 0.0;
+      if ((init_p_flag == true) && ((var_name.substr(0, 9) == "pressure:") ||
+                                    (var_name.substr(0, 4) == "P_c:"))) {
+        default_val = init_p;
+        DEBUG_MSG("pressure_all initial condition for " << var_name);
+      } else if ((init_q_flag == true) && (var_name.substr(0, 5) == "flow:")) {
+        default_val = init_q;
+        DEBUG_MSG("flow_all initial condition for " << var_name);
+      } else {
+        DEBUG_MSG("No initial condition found for " << var_name);
       }
+      initial_state.y[i] = initial_condition.get_double(var_name, default_val);
     }
-  } catch (simdjson::simdjson_error) {
   }
   DEBUG_MSG("[configreader] END");
 }

--- a/src/io/configreader.hpp
+++ b/src/io/configreader.hpp
@@ -650,6 +650,21 @@ void ConfigReader<T>::load(JsonHandler &handler) {
     }
   }
 
+  // Sanity checks
+  bool model_is_valid = true;
+  if (block_count != model->blocks.size()) {
+    model_is_valid = false;
+  }
+  if (block_count != model->block_index_map.size()) {
+    model_is_valid = false;
+  }
+  if (model_is_valid == false) {
+    throw std::runtime_error(
+        "Model sanity check failed: An unexpected error occured while loading "
+        "the configuration. This is likely an implementation issue. Please "
+        "contact a developer.");
+  }
+
   // Setup degrees of freedom of the system
   for (auto &block : model->blocks) {
     block->setup_dofs(model->dofhandler);

--- a/src/io/configreader.hpp
+++ b/src/io/configreader.hpp
@@ -592,6 +592,7 @@ void ConfigReader<T>::load(JsonHandler &handler) {
                 static_cast<std::string>(heartpulmonary_name)));
             model->block_index_map.insert(
                 {static_cast<std::string>(heartpulmonary_name), block_count});
+            block_count++;
           } else {
             throw std::runtime_error(
                 "Error. ClosedLoopHeartAndPulmonary should have 27 parameters");
@@ -605,6 +606,7 @@ void ConfigReader<T>::load(JsonHandler &handler) {
           model->block_index_map.insert(
               {static_cast<std::string>(heart_inlet_junction_name),
                block_count});
+          block_count++;
           for (auto heart_inlet_elem : closed_loop_bcs) {
             connections.push_back(
                 {heart_inlet_elem, heart_inlet_junction_name});
@@ -621,12 +623,12 @@ void ConfigReader<T>::load(JsonHandler &handler) {
           for (auto outlet_block :
                closed_loop_config.get_string_array("outlet_blocks")) {
             connections.push_back({heart_outlet_junction_name, outlet_block});
+            block_count++;
           }
         } else {
           throw std::runtime_error(
               "Error. Only one ClosedLoopHeartAndPulmonary can be included.");
         }
-        block_count++;
       }
     }
   }

--- a/src/io/csvwriter.hpp
+++ b/src/io/csvwriter.hpp
@@ -123,16 +123,16 @@ std::string to_vessel_csv(std::vector<T> &times,
           d_outflow_mean /= num_steps;
           d_inpres_mean /= num_steps;
           d_outpres_mean /= num_steps;
-          sprintf(lbuff,
-                  "%s,,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e\n",
-                  name.c_str(), inflow_mean, outflow_mean, inpres_mean,
-                  outpres_mean, d_inflow_mean, d_outflow_mean, d_inpres_mean,
-                  d_outpres_mean);
+          snprintf(lbuff, 236,
+                   "%s,,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e\n",
+                   name.c_str(), inflow_mean, outflow_mean, inpres_mean,
+                   outpres_mean, d_inflow_mean, d_outflow_mean, d_inpres_mean,
+                   d_outpres_mean);
           out << lbuff;
         } else {
           for (size_t i = 0; i < num_steps; i++) {
-            sprintf(
-                lbuff,
+            snprintf(
+                lbuff, 236,
                 "%s,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e,%.16e\n",
                 name.c_str(), times[i], states[i].y[inflow_dof],
                 states[i].y[outflow_dof], states[i].y[inpres_dof],
@@ -160,14 +160,15 @@ std::string to_vessel_csv(std::vector<T> &times,
           outflow_mean /= num_steps;
           inpres_mean /= num_steps;
           outpres_mean /= num_steps;
-          sprintf(sbuff, "%s,,%.16e,%.16e,%.16e,%.16e\n", name.c_str(),
-                  inflow_mean, outflow_mean, inpres_mean, outpres_mean);
+          snprintf(sbuff, 140, "%s,,%.16e,%.16e,%.16e,%.16e\n", name.c_str(),
+                   inflow_mean, outflow_mean, inpres_mean, outpres_mean);
           out << sbuff;
         } else {
           for (size_t i = 0; i < num_steps; i++) {
-            sprintf(sbuff, "%s,%.16e,%.16e,%.16e,%.16e,%.16e\n", name.c_str(),
-                    times[i], states[i].y[inflow_dof], states[i].y[outflow_dof],
-                    states[i].y[inpres_dof], states[i].y[outpres_dof]);
+            snprintf(sbuff, 140, "%s,%.16e,%.16e,%.16e,%.16e,%.16e\n",
+                     name.c_str(), times[i], states[i].y[inflow_dof],
+                     states[i].y[outflow_dof], states[i].y[inpres_dof],
+                     states[i].y[outpres_dof]);
             out << sbuff;
           }
         }
@@ -218,15 +219,16 @@ std::string to_variable_csv(std::vector<T> &times,
         }
         mean_y /= num_steps;
         mean_ydot /= num_steps;
-        sprintf(lbuff, "%s,,%.16e,%.16e\n", name.c_str(), mean_y, mean_ydot);
+        snprintf(lbuff, 110, "%s,,%.16e,%.16e\n", name.c_str(), mean_y,
+                 mean_ydot);
         out << lbuff;
       }
     } else {
       for (size_t i = 0; i < model.dofhandler.size(); i++) {
         std::string name = model.dofhandler.variables[i];
         for (size_t j = 0; j < num_steps; j++) {
-          sprintf(lbuff, "%s,%.16e,%.16e,%.16e\n", name.c_str(), times[j],
-                  states[j].y[i], states[j].ydot[i]);
+          snprintf(lbuff, 110, "%s,%.16e,%.16e,%.16e\n", name.c_str(), times[j],
+                   states[j].y[i], states[j].ydot[i]);
           out << lbuff;
         }
       }
@@ -241,15 +243,15 @@ std::string to_variable_csv(std::vector<T> &times,
           mean_y += states[j].y[i];
         }
         mean_y /= num_steps;
-        sprintf(sbuff, "%s,,%.16e\n", name.c_str(), mean_y);
+        snprintf(sbuff, 87, "%s,,%.16e\n", name.c_str(), mean_y);
         out << sbuff;
       }
     } else {
       for (size_t i = 0; i < model.dofhandler.size(); i++) {
         std::string name = model.dofhandler.variables[i];
         for (size_t j = 0; j < num_steps; j++) {
-          sprintf(sbuff, "%s,%.16e,%.16e\n", name.c_str(), times[j],
-                  states[j].y[i]);
+          snprintf(sbuff, 87, "%s,%.16e,%.16e\n", name.c_str(), times[j],
+                   states[j].y[i]);
           out << sbuff;
         }
       }

--- a/src/io/jsonhandler.hpp
+++ b/src/io/jsonhandler.hpp
@@ -47,35 +47,158 @@ class JsonHandler {
   simdjson::dom::parser *parser;
 
  public:
+  /**
+   * @brief Construct a new JsonHandler object
+   *
+   * @param json_encoded_string JSON encoded string
+   */
   JsonHandler(std::string_view json_encoded_string);
+
+  /**
+   * @brief Construct a new JsonHandler object
+   *
+   * @param data simdjson data
+   */
   JsonHandler(simdjson::simdjson_result<simdjson::dom::element> data);
+
+  /**
+   * @brief Destroy the JsonHandler object
+   *
+   */
   ~JsonHandler();
 
+  /**
+   * @brief Returns the lengths of the data if it can be cast to an array
+   *
+   * @return int Length of the data
+   */
   int length();
+
+  /**
+   * @brief Check if JSON data has a certain key
+   *
+   * @param key
+   * @return true If key exists
+   * @return false If key doesn't exist
+   */
   bool has_key(std::string_view key);
 
+  /**
+   * @brief Get the inner JSON object at a string key
+   *
+   * @param key JSON key
+   * @return JsonHandler Inner JSON object at the key
+   */
   JsonHandler operator[](std::string_view key);
+
+  /**
+   * @brief Get the inner JSON object at an integer key
+   *
+   * @param index JSON index
+   * @return JsonHandler
+   */
   JsonHandler operator[](int index);
 
+  /**
+   * @brief Get boolean parameter
+   *
+   * @param key Key of the parameter
+   * @return bool Value of the parameter
+   */
   bool get_bool(std::string_view key);
+
+  /**
+   * @brief Get boolean parameter with default value
+   *
+   * @param key Key of the parameter
+   * @param default_value Value to return if key doesn't exist
+   * @return bool Value of the parameter or default value if key doesn't exist
+   */
   bool get_bool(std::string_view key, bool default_value);
 
+  /**
+   * @brief Get integer parameter
+   *
+   * @param key Key of the parameter
+   * @return int Value of the parameter
+   */
   int get_int(std::string_view key);
+
+  /**
+   * @brief Get integer parameter with default value
+   *
+   * @param key Key of the parameter
+   * @param default_value Value to return if key doesn't exist
+   * @return int Value of the parameter or default value if key doesn't exist
+   */
   int get_int(std::string_view key, int default_value);
 
+  /**
+   * @brief Get double parameter
+   *
+   * @param key Key of the parameter
+   * @return double Value of the parameter
+   */
   double get_double(std::string_view key);
+
+  /**
+   * @brief Get double parameter with default value
+   *
+   * @param key Key of the parameter
+   * @param default_value Value to return if key doesn't exist
+   * @return double Value of the parameter or default value if key doesn't exist
+   */
   double get_double(std::string_view key, double default_value);
 
+  /**
+   * @brief Get double array parameter
+   *
+   * @param key Key of the parameter
+   * @return std::vector<double> Value of the parameter
+   */
   std::vector<double> get_double_array(std::string_view key);
+
+  /**
+   * @brief Get double array parameter with default value
+   *
+   * @param key Key of the parameter
+   * @param default_value Value to return if key doesn't exist
+   * @return std::vector<double> Value of the parameter or default value if key
+   * doesn't exist
+   */
   std::vector<double> get_double_array(std::string_view key,
                                        std::vector<double> default_value);
 
+  /**
+   * @brief Get integer array parameter
+   *
+   * @param key Key of the parameter
+   * @return std::vector<int> Value of the parameter
+   */
   std::vector<int> get_int_array(std::string_view key);
 
+  /**
+   * @brief Get string parameter
+   *
+   * @param key Key of the parameter
+   * @return std::string_view Value of the parameter
+   */
   std::string_view get_string(std::string_view key);
 
+  /**
+   * @brief Get string array parameter
+   *
+   * @param key Key of the parameter
+   * @return std::vector<std::string_view> Value of the parameter
+   */
   std::vector<std::string_view> get_string_array(std::string_view key);
 
+  /**
+   * @brief Get the list parameter
+   *
+   * @param key Key of the parameter
+   * @return std::list<JsonHandler> Value of the parameter
+   */
   std::list<JsonHandler> get_list(std::string_view key);
 };
 
@@ -84,6 +207,7 @@ JsonHandler::JsonHandler(std::string_view json_encoded_string) {
   auto string = simdjson::padded_string(json_encoded_string);
   data = parser->parse(string);
 }
+
 JsonHandler::JsonHandler(
     simdjson::simdjson_result<simdjson::dom::element> data) {
   this->data = data;

--- a/src/io/jsonhandler.hpp
+++ b/src/io/jsonhandler.hpp
@@ -1,0 +1,268 @@
+// Copyright (c) Stanford University, The Regents of the University of
+//               California, and others.
+//
+// All Rights Reserved.
+//
+// See Copyright-SimVascular.txt for additional details.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject
+// to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/**
+ * @file jsonhandler.hpp
+ * @brief IO::JsonHandler source file
+ */
+#ifndef SVZERODSOLVER_IO_JSONHANDLER_HPP_
+#define SVZERODSOLVER_IO_JSONHANDLER_HPP_
+
+#include <stdexcept>
+#include <string>
+
+#include "simdjson.h"
+
+namespace IO {
+
+class JsonHandler {
+ private:
+  simdjson::simdjson_result<simdjson::dom::element> data;
+  simdjson::dom::parser *parser;
+
+ public:
+  JsonHandler(std::string_view json_encoded_string);
+  JsonHandler(simdjson::simdjson_result<simdjson::dom::element> data);
+  ~JsonHandler();
+
+  int length();
+  bool has_key(std::string_view key);
+
+  JsonHandler operator[](std::string_view key);
+  JsonHandler operator[](int index);
+
+  bool get_bool(std::string_view key);
+  bool get_bool(std::string_view key, bool default_value);
+
+  int get_int(std::string_view key);
+  int get_int(std::string_view key, int default_value);
+
+  double get_double(std::string_view key);
+  double get_double(std::string_view key, double default_value);
+
+  std::vector<double> get_double_array(std::string_view key);
+  std::vector<double> get_double_array(std::string_view key,
+                                       std::vector<double> default_value);
+
+  std::vector<int> get_int_array(std::string_view key);
+
+  std::string_view get_string(std::string_view key);
+
+  std::vector<std::string_view> get_string_array(std::string_view key);
+
+  std::list<JsonHandler> get_list(std::string_view key);
+};
+
+JsonHandler::JsonHandler(std::string_view json_encoded_string) {
+  parser = new simdjson::dom::parser();
+  auto string = simdjson::padded_string(json_encoded_string);
+  data = parser->parse(string);
+}
+JsonHandler::JsonHandler(
+    simdjson::simdjson_result<simdjson::dom::element> data) {
+  this->data = data;
+}
+
+JsonHandler::~JsonHandler() {}
+
+int JsonHandler::length() {
+  int size;
+  try {
+    size = data.get_array().size();
+  } catch (simdjson::simdjson_error) {
+    throw std::runtime_error("Not an array");
+  }
+  return size;
+}
+
+bool JsonHandler::has_key(std::string_view key) {
+  bool has_key = false;
+  for (auto &&field : data.get_object()) {
+    if (field.key == key) {
+      has_key = true;
+    }
+  }
+  return has_key;
+}
+
+JsonHandler JsonHandler::operator[](std::string_view key) {
+  if (!has_key(key)) {
+    throw std::runtime_error("Key not found: " + static_cast<std::string>(key));
+  }
+  return JsonHandler(data.at_key(key));
+}
+
+JsonHandler JsonHandler::operator[](int index) {
+  simdjson::simdjson_result<simdjson::dom::element> output;
+  try {
+    output = data.get_array().at(index);
+  } catch (simdjson::simdjson_error) {
+    throw std::runtime_error("Index out of range: " + std::to_string(index));
+  }
+  return JsonHandler(output);
+}
+
+bool JsonHandler::get_bool(std::string_view key) {
+  bool output;
+  try {
+    output = data.at_key(key).get_bool();
+  } catch (simdjson::simdjson_error) {
+    throw std::runtime_error("Key not found: " + static_cast<std::string>(key));
+  }
+  return output;
+}
+
+bool JsonHandler::get_bool(std::string_view key, bool default_value) {
+  try {
+    return data.at_key(key).get_bool();
+  } catch (simdjson::simdjson_error) {
+    return default_value;
+  }
+}
+
+int JsonHandler::get_int(std::string_view key) {
+  int output;
+  try {
+    output = data.at_key(key).get_int64();
+  } catch (simdjson::simdjson_error) {
+    throw std::runtime_error("Key not found: " + static_cast<std::string>(key));
+  }
+  return output;
+}
+
+int JsonHandler::get_int(std::string_view key, int default_value) {
+  try {
+    return data.at_key(key).get_int64();
+  } catch (simdjson::simdjson_error) {
+    return default_value;
+  }
+}
+
+double JsonHandler::get_double(std::string_view key) {
+  double output;
+  try {
+    output = data.at_key(key).get_double();
+  } catch (simdjson::simdjson_error) {
+    throw std::runtime_error("Key not found: " + static_cast<std::string>(key));
+  }
+  return output;
+}
+
+double JsonHandler::get_double(std::string_view key, double default_value) {
+  try {
+    return data.at_key(key).get_double();
+  } catch (simdjson::simdjson_error) {
+    return default_value;
+  }
+}
+
+std::vector<double> JsonHandler::get_double_array(std::string_view key) {
+  std::vector<double> vector;
+  try {
+    for (auto x : data.at_key(key).get_array()) {
+      vector.push_back(x.get_double());
+    }
+  } catch (simdjson::simdjson_error) {
+    try {
+      vector.push_back(data.at_key(key).get_double());
+    } catch (simdjson::simdjson_error) {
+      throw std::runtime_error("Key not found: " +
+                               static_cast<std::string>(key));
+    }
+  };
+  return vector;
+}
+
+std::vector<double> JsonHandler::get_double_array(
+    std::string_view key, std::vector<double> default_value) {
+  std::vector<double> vector;
+  try {
+    for (auto x : data.at_key(key).get_array()) {
+      vector.push_back(x.get_double());
+    }
+  } catch (simdjson::simdjson_error) {
+    try {
+      vector.push_back(data.at_key(key).get_double());
+    } catch (simdjson::simdjson_error) {
+      return default_value;
+    }
+  };
+  return vector;
+}
+
+std::vector<int> JsonHandler::get_int_array(std::string_view key) {
+  std::vector<int> vector;
+  try {
+    for (auto x : data.at_key(key).get_array()) {
+      int val = x.get_int64();
+      vector.push_back(val);
+    }
+  } catch (simdjson::simdjson_error) {
+    try {
+      int val = data.at_key(key).get_int64();
+      vector.push_back(val);
+    } catch (simdjson::simdjson_error) {
+      throw std::runtime_error("Key not found: " +
+                               static_cast<std::string>(key));
+    }
+  };
+  return vector;
+}
+
+std::string_view JsonHandler::get_string(std::string_view key) {
+  std::string_view output;
+  try {
+    output = data.at_key(key).get_string();
+  } catch (simdjson::simdjson_error) {
+    throw std::runtime_error("Key not found: " + static_cast<std::string>(key));
+  }
+  return output;
+}
+
+std::vector<std::string_view> JsonHandler::get_string_array(
+    std::string_view key) {
+  std::vector<std::string_view> vector;
+  try {
+    for (auto x : data.at_key(key).get_array()) {
+      vector.push_back(x.get_string());
+    }
+  } catch (simdjson::simdjson_error) {
+    try {
+      vector.push_back(data.at_key(key).get_string());
+    } catch (simdjson::simdjson_error) {
+      throw std::runtime_error("Key not found: " +
+                               static_cast<std::string>(key));
+    }
+  };
+  return vector;
+}
+
+}  // namespace IO
+
+#endif  // SVZERODSOLVER_IO_JSONHANDLER_HPP_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,9 +62,9 @@ int main(int argc, char *argv[]) {
   std::string input_file = argv[1];
   std::string output_file = argv[2];
 
-  std::ifstream t(input_file);
+  std::ifstream input_file_stream(input_file);
   std::stringstream buffer;
-  buffer << t.rdbuf();
+  buffer << input_file_stream.rdbuf();
   std::string config = buffer.str();
 
   auto output = run(config);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,12 @@ int main(int argc, char *argv[]) {
   std::string input_file = argv[1];
   std::string output_file = argv[2];
 
-  auto output = run(input_file);
+  std::ifstream t(input_file);
+  std::stringstream buffer;
+  buffer << t.rdbuf();
+  std::string config = buffer.str();
+
+  auto output = run(config);
 
   std::ofstream ofs(output_file);
   ofs << output;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -234,7 +234,7 @@ typedef double T;
  * @param json_config Path config or json encoded string with config
  * @return Result as csv encoded string
  */
-const std::string run(std::string& json_config) {
+const std::string run(std::string_view json_config) {
   // Load model and configuration
   DEBUG_MSG("Read configuration");
   IO::ConfigReader<T> reader;

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -215,6 +215,7 @@
 #include "helpers/endswith.hpp"
 #include "io/configreader.hpp"
 #include "io/csvwriter.hpp"
+#include "io/jsonhandler.hpp"
 #include "model/model.hpp"
 
 // Setting scalar type to double
@@ -237,7 +238,8 @@ const std::string run(std::string& json_config) {
   // Load model and configuration
   DEBUG_MSG("Read configuration");
   IO::ConfigReader<T> reader;
-  reader.load(json_config);
+  auto handler = IO::JsonHandler(json_config);
+  reader.load(handler);
 
   // Setup system
   ALGEBRA::State<T> state = reader.initial_state;
@@ -247,9 +249,12 @@ const std::string run(std::string& json_config) {
     DEBUG_MSG("Calculate steady initial condition");
     T time_step_size_steady = reader.sim_cardiac_cycle_period / 10.0;
     reader.model->to_steady();
-    ALGEBRA::Integrator<T> integrator_steady(*reader.model, time_step_size_steady, 0.1, reader.sim_abs_tol, reader.sim_nliter);
+    ALGEBRA::Integrator<T> integrator_steady(
+        *reader.model, time_step_size_steady, 0.1, reader.sim_abs_tol,
+        reader.sim_nliter);
     for (int i = 0; i < 31; i++) {
-      state = integrator_steady.step(state, time_step_size_steady * T(i),*reader.model);
+      state = integrator_steady.step(state, time_step_size_steady * T(i),
+                                     *reader.model);
     }
     reader.model->to_unsteady();
   }

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -37,7 +37,7 @@
 
 PYBIND11_MODULE(libsvzerodsolver, mod) {
   mod.doc() = "svZeroDSolver";
-  mod.def("run", [](std::string& json_config) {
+  mod.def("run", [](std::string_view json_config) {
     return pybind11::bytes(run(json_config));
   });
 }


### PR DESCRIPTION
As a prerequisite for #24, I wanted to clean up the configuration reading a bit by splitting the JSON handling from the actual config reading, as a lot of code redundancy resulted from that and the config reader got really messy.

On the way, I made a few other modifications that can be helpful:

* Fixed the Debug build of svZeroDSolver (no weird error anymore)
* DEBUG messages are automatically turned on for Debug builds (`-DCMAKE_BUILD_TYPE=Debug`) and turned of for Release builds (this would resolve #21)
* Fixed deprecation warning caused by `sprintf` by replacing it with `snprintf`
* Make use of `string_view` instead of `string` when feasible