### PR TITLE
Upgrade to Doxygen 1.9.6

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,7 +12,7 @@ jobs:
         run: mkdir docs/build
       - name: Build doxygen documentation
         continue-on-error: true
-        uses: mattnotmitt/doxygen-action@v1.9.5
+        uses: mattnotmitt/doxygen-action@edge
         with:
           working-directory: '.'
           doxyfile-path: 'docs/Doxyfile'


### PR DESCRIPTION
LaTeX formulas are not rendered correctly after merging #57. I hope an upgrade from Doxygen 1.9.5 to 1.9.6 ([latest available in GitHub action](https://github.com/marketplace/actions/doxygen-action)) will help. I use Doxygen 1.9.8 locally.